### PR TITLE
Fix async worklog router and add httpx dependency

### DIFF
--- a/app/routers/worklogs.py
+++ b/app/routers/worklogs.py
@@ -1,6 +1,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlmodel import Session, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 from app.database import get_session
 from app.models import WorkLog, Object
 from app.schemas import WorkLogCreate, WorkLogRead
@@ -8,17 +9,18 @@ from app.schemas import WorkLogCreate, WorkLogRead
 router = APIRouter(prefix="/worklogs", tags=["worklogs"])
 
 @router.post("/", response_model=WorkLogRead, status_code=status.HTTP_201_CREATED)
-def create_log(payload: WorkLogCreate, session: Session = Depends(get_session)):
+async def create_log(payload: WorkLogCreate, session: AsyncSession = Depends(get_session)):
     # simple existence check
-    obj = session.get(Object, payload.object_id)
+    obj = await session.get(Object, payload.object_id)
     if not obj:
         raise HTTPException(status_code=404, detail="Object not found")
     log = WorkLog(**payload.dict())
     session.add(log)
-    session.commit()
-    session.refresh(log)
+    await session.commit()
+    await session.refresh(log)
     return log
 
 @router.get("/", response_model=list[WorkLogRead])
-def list_logs(session: Session = Depends(get_session)):
-    return session.exec(select(WorkLog)).all()
+async def list_logs(session: AsyncSession = Depends(get_session)):
+    result = await session.execute(select(WorkLog))
+    return result.scalars().all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ asyncpg==0.29.0
 alembic==1.13.1
 python-multipart==0.0.7
 boto3==1.34.96
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- ensure worklog router uses AsyncSession and async functions
- add missing `httpx` package to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: could not find a version due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6848c2c32c7083228cf09704e478cdc7