### PR TITLE
Fix worklog API and update interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+frontend/node_modules/
+frontend/dist/
+frontend/package-lock.json

--- a/app/routers/worklogs.py
+++ b/app/routers/worklogs.py
@@ -9,9 +9,12 @@ from app.schemas import WorkLogCreate, WorkLogRead
 router = APIRouter(prefix="/worklogs", tags=["worklogs"])
 
 @router.post("/", response_model=WorkLogRead, status_code=status.HTTP_201_CREATED)
-def create_log(payload: WorkLogCreate, session: Session = Depends(get_session)):
+async def create_log(
+    payload: WorkLogCreate,
+    session: AsyncSession = Depends(get_session),
+):
     # ensure referenced work order exists
-    order = session.get(WorkOrder, payload.work_order_id)
+    order = await session.get(WorkOrder, payload.work_order_id)
     if not order:
         raise HTTPException(status_code=404, detail="Work order not found")
     log = WorkLog(**payload.dict())

--- a/frontend/src/pages/WorklogsPage.tsx
+++ b/frontend/src/pages/WorklogsPage.tsx
@@ -1,51 +1,61 @@
 
 import React, { useState, useEffect } from 'react'
-import { TextField, Button, List, ListItem, ListItemText, Paper, Stack, MenuItem, Select } from '@mui/material'
+import { TextField, Button, List, ListItem, ListItemText, Paper, Stack } from '@mui/material'
 
-interface Obj { id: number; name: string }
-interface Log { id: number; description: string; object_id: number; performed_at: string }
+interface Log {
+  id: number
+  description: string
+  work_order_id: number
+  performer_id: number
+  performed_at: string
+}
 
 export default function WorklogsPage() {
-  const [objects, setObjects] = useState<Obj[]>([])
   const [logs, setLogs] = useState<Log[]>([])
-  const [objectId, setObjectId] = useState<number | ''>('')
+  const [workOrderId, setWorkOrderId] = useState('')
+  const [performerId, setPerformerId] = useState('')
   const [description, setDescription] = useState('')
 
   const load = async () => {
-    const [o, l] = await Promise.all([
-      fetch('http://localhost:8000/objects').then(r=>r.json()),
-      fetch('http://localhost:8000/worklogs').then(r=>r.json())
-    ])
-    setObjects(o); setLogs(l)
+    const l = await fetch('http://localhost:8000/worklogs').then(r => r.json())
+    setLogs(l)
   }
 
   useEffect(()=>{load()},[])
 
   const add = async () => {
-    if(!objectId) return
+    if(!workOrderId || !performerId) return
     await fetch('http://localhost:8000/worklogs', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({object_id: objectId, description })
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        work_order_id: Number(workOrderId),
+        performer_id: Number(performerId),
+        description,
+      }),
     })
-    setDescription(''); setObjectId(''); load()
+    setDescription('')
+    setWorkOrderId('')
+    setPerformerId('')
+    load()
   }
-
-  const objName = (id:number)=>objects.find(o=>o.id===id)?.name || id
 
   return (
     <Paper sx={{p:3}}>
       <Stack spacing={2}>
-        <Select displayEmpty value={objectId} onChange={e=>setObjectId(e.target.value as any)}>
-          <MenuItem value=''><em>Select Object</em></MenuItem>
-          {objects.map(o=><MenuItem key={o.id} value={o.id}>{o.name}</MenuItem>)}
-        </Select>
+        <TextField label="Work Order ID" value={workOrderId} onChange={e=>setWorkOrderId(e.target.value)} />
+        <TextField label="Performer ID" value={performerId} onChange={e=>setPerformerId(e.target.value)} />
         <TextField label="Description" value={description} onChange={e=>setDescription(e.target.value)}/>
         <Button variant="contained" onClick={add}>Add</Button>
         <List dense>
-          {logs.map(l=>(<ListItem key={l.id}>
-            <ListItemText primary={l.description} secondary={objName(l.object_id)+' – '+new Date(l.performed_at).toLocaleString()}/>
-          </ListItem>))}
+          {logs.map(l=>(
+            <ListItem key={l.id}>
+              <ListItemText
+                primary={l.description}
+                secondary={`WO ${l.work_order_id} by ${l.performer_id} – ` + new Date(l.performed_at).toLocaleString()}
+              />
+            </ListItem>
+          ))}
         </List>
       </Stack>
     </Paper>

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,10 +1,74 @@
 
 from fastapi.testclient import TestClient
+
+import os
+import sys
+import asyncio
+import tempfile
+import datetime as dt
+from typing import Generator
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+temp_db = tempfile.NamedTemporaryFile(delete=False)
+os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{temp_db.name}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup() -> Generator[None, None, None]:
+    yield
+    try:
+        os.unlink(temp_db.name)
+    except FileNotFoundError:
+        pass
+
 from app.main import app
+from app.database import async_session
+from app.models import WorkOrder
 
-client = TestClient(app)
 
-def test_root():
+@pytest.fixture(scope="module")
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as c:
+        yield c
+
+
+def test_root(client: TestClient):
     r = client.get("/")
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}
+
+
+def test_object_crud(client: TestClient):
+    r = client.post("/objects/", json={"name": "Obj1", "address": "Addr"})
+    assert r.status_code == 201
+    created = r.json()
+
+    r = client.get("/objects/")
+    assert r.status_code == 200
+    assert any(o["id"] == created["id"] for o in r.json())
+
+
+def test_worklog_flow(client: TestClient):
+    async def create_order():
+        async with async_session() as session:
+            wo = WorkOrder(scheduled_for=dt.date.today())
+            session.add(wo)
+            await session.commit()
+            await session.refresh(wo)
+            return wo.id
+
+    wo_id = asyncio.run(create_order())
+
+    r = client.post(
+        "/worklogs/",
+        json={"work_order_id": wo_id, "performer_id": 1, "description": "test"},
+    )
+    assert r.status_code == 201
+
+    r = client.get("/worklogs/")
+    assert r.status_code == 200
+    assert any(l["work_order_id"] == wo_id for l in r.json())
+


### PR DESCRIPTION
## Summary
- fix `worklogs.create_log` to be async
- adjust test path so `app` package is discovered
- ignore build artifacts in `.gitignore`
- rework WorklogsPage to match updated API
- add SQLite-based integration tests for objects and worklogs
- clean up temporary DB teardown logic

## Testing
- `npm --prefix frontend run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849119ffa7883228d2fbfddfc349586