### PR TITLE
Add Go and Flutter skeleton services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Eventoria
+
+This repository contains a minimal maintenance management prototype.
+
+## Services
+
+- **FastAPI backend** (`api` service) – existing Python service serving REST
+  endpoints for objects and work logs.
+- **Go backend** (`go-api` service) – simple Gin/GORM API in `backend/`.
+- **React frontend** (`frontend` service) – existing web UI.
+- **Flutter frontend** (`flutter-web` service) – Flutter web app in
+  `frontend_flutter/`.
+
+The project can be started locally via Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+Run unit tests with `pytest`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /src
+COPY go.mod .
+RUN go mod download
+COPY . .
+RUN go build -o server .
+
+FROM alpine
+WORKDIR /app
+COPY --from=build /src/server ./server
+CMD ["./server"]

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,9 @@
+module eventoria/backend
+
+go 1.21
+
+require (
+    github.com/gin-gonic/gin v1.10.1
+    gorm.io/driver/sqlite v1.5.6
+    gorm.io/gorm v1.25.7
+)

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Data models
+
+type Object struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Name      string    `json:"name"`
+	Address   string    `json:"address"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type WorkOrder struct {
+	ID           uint      `json:"id" gorm:"primaryKey"`
+	ScheduledFor time.Time `json:"scheduled_for"`
+	Status       string    `json:"status"`
+}
+
+type WorkLog struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
+	WorkOrderID uint      `json:"work_order_id"`
+	PerformedAt time.Time `json:"performed_at"`
+	PerformerID uint      `json:"performer_id"`
+	Description string    `json:"description"`
+}
+
+func setupDB() *gorm.DB {
+	db, err := gorm.Open(sqlite.Open("data.db"), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+	if err := db.AutoMigrate(&Object{}, &WorkOrder{}, &WorkLog{}); err != nil {
+		panic(err)
+	}
+	return db
+}
+
+func main() {
+	db := setupDB()
+	r := gin.Default()
+
+	r.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	// Objects
+	r.POST("/objects", func(c *gin.Context) {
+		var o Object
+		if err := c.ShouldBindJSON(&o); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err := db.Create(&o).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, o)
+	})
+	r.GET("/objects", func(c *gin.Context) {
+		var list []Object
+		if err := db.Find(&list).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, list)
+	})
+
+	// Work orders (minimal)
+	r.POST("/workorders", func(c *gin.Context) {
+		var o WorkOrder
+		if err := c.ShouldBindJSON(&o); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if o.Status == "" {
+			o.Status = "PENDING"
+		}
+		if err := db.Create(&o).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, o)
+	})
+	r.GET("/workorders", func(c *gin.Context) {
+		var list []WorkOrder
+		if err := db.Find(&list).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, list)
+	})
+
+	// Work logs
+	r.POST("/worklogs", func(c *gin.Context) {
+		var wl WorkLog
+		if err := c.ShouldBindJSON(&wl); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		var order WorkOrder
+		if err := db.First(&order, wl.WorkOrderID).Error; err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "work order not found"})
+			return
+		}
+		if wl.PerformedAt.IsZero() {
+			wl.PerformedAt = time.Now()
+		}
+		if err := db.Create(&wl).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, wl)
+	})
+	r.GET("/worklogs", func(c *gin.Context) {
+		var list []WorkLog
+		if err := db.Find(&list).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, list)
+	})
+
+	r.Run(":8080")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,18 @@ services:
       sign-mock:
         condition: service_started
 
+  go-api:
+    build: ./backend
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+      minio:
+        condition: service_started
+      sign-mock:
+        condition: service_started
+
   db:
     image: postgres:15
     environment:
@@ -55,4 +67,12 @@ services:
     - "3000:80"
     depends_on:
       api:
+        condition: service_started
+
+  flutter-web:
+    build: ./frontend_flutter
+    ports:
+      - "8081:80"
+    depends_on:
+      go-api:
         condition: service_started

--- a/frontend_flutter/Dockerfile
+++ b/frontend_flutter/Dockerfile
@@ -1,0 +1,7 @@
+FROM cirrusci/flutter:3.19.6 as build
+WORKDIR /app
+COPY . .
+RUN flutter build web
+
+FROM nginx:alpine
+COPY --from=build /app/build/web /usr/share/nginx/html

--- a/frontend_flutter/README.md
+++ b/frontend_flutter/README.md
@@ -1,0 +1,12 @@
+# Flutter Frontend
+
+This directory contains the Flutter web client. The application shows
+object and work log lists and allows creating new ones.
+
+To run locally you need Flutter SDK installed. Then execute:
+
+```bash
+flutter run -d chrome
+```
+
+For production builds the provided Dockerfile compiles the web assets.

--- a/frontend_flutter/lib/main.dart
+++ b/frontend_flutter/lib/main.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'pages/objects_page.dart';
+import 'pages/worklogs_page.dart';
+
+void main() {
+  runApp(const EventoriaApp());
+}
+
+class EventoriaApp extends StatelessWidget {
+  const EventoriaApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Eventoria',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _index = 0;
+  final _pages = [const ObjectsPage(), const WorkLogsPage()];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Objects'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Logs'),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend_flutter/lib/pages/objects_page.dart
+++ b/frontend_flutter/lib/pages/objects_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import '../services/api.dart';
+
+class ObjectsPage extends StatefulWidget {
+  const ObjectsPage({super.key});
+
+  @override
+  State<ObjectsPage> createState() => _ObjectsPageState();
+}
+
+class _ObjectsPageState extends State<ObjectsPage> {
+  late Future<List<dynamic>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = fetchObjects();
+  }
+
+  void _refresh() {
+    setState(() {
+      _future = fetchObjects();
+    });
+  }
+
+  Future<void> _addObject() async {
+    final nameCtrl = TextEditingController();
+    final addrCtrl = TextEditingController();
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New Object'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(controller: nameCtrl, decoration: const InputDecoration(labelText: 'Name')),
+            TextField(controller: addrCtrl, decoration: const InputDecoration(labelText: 'Address')),
+          ],
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          ElevatedButton(
+            onPressed: () async {
+              await createObject({'name': nameCtrl.text, 'address': addrCtrl.text});
+              Navigator.pop(context);
+              _refresh();
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Objects')),
+      floatingActionButton: FloatingActionButton(onPressed: _addObject, child: const Icon(Icons.add)),
+      body: FutureBuilder<List<dynamic>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final items = snapshot.data ?? [];
+          return ListView.builder(
+            itemCount: items.length,
+            itemBuilder: (context, i) {
+              final o = items[i];
+              return ListTile(
+                title: Text(o['name']),
+                subtitle: Text(o['address']),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend_flutter/lib/pages/worklogs_page.dart
+++ b/frontend_flutter/lib/pages/worklogs_page.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import '../services/api.dart';
+
+class WorkLogsPage extends StatefulWidget {
+  const WorkLogsPage({super.key});
+
+  @override
+  State<WorkLogsPage> createState() => _WorkLogsPageState();
+}
+
+class _WorkLogsPageState extends State<WorkLogsPage> {
+  late Future<List<dynamic>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = fetchWorkLogs();
+  }
+
+  void _refresh() {
+    setState(() {
+      _future = fetchWorkLogs();
+    });
+  }
+
+  Future<void> _addLog() async {
+    final woCtrl = TextEditingController();
+    final perfCtrl = TextEditingController();
+    final descCtrl = TextEditingController();
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New WorkLog'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(controller: woCtrl, decoration: const InputDecoration(labelText: 'WorkOrder ID')),
+            TextField(controller: perfCtrl, decoration: const InputDecoration(labelText: 'Performer ID')),
+            TextField(controller: descCtrl, decoration: const InputDecoration(labelText: 'Description')),
+          ],
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          ElevatedButton(
+            onPressed: () async {
+              await createWorkLog({
+                'work_order_id': int.tryParse(woCtrl.text) ?? 0,
+                'performer_id': int.tryParse(perfCtrl.text) ?? 0,
+                'description': descCtrl.text,
+              });
+              Navigator.pop(context);
+              _refresh();
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Work Logs')),
+      floatingActionButton: FloatingActionButton(onPressed: _addLog, child: const Icon(Icons.add)),
+      body: FutureBuilder<List<dynamic>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final items = snapshot.data ?? [];
+          return ListView.builder(
+            itemCount: items.length,
+            itemBuilder: (context, i) {
+              final l = items[i];
+              return ListTile(
+                title: Text('Order ${l['work_order_id']}'),
+                subtitle: Text(l['description']),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend_flutter/lib/services/api.dart
+++ b/frontend_flutter/lib/services/api.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+const baseUrl = String.fromEnvironment('API_BASE', defaultValue: 'http://localhost:8080');
+
+Future<List<dynamic>> fetchObjects() async {
+  final res = await http.get(Uri.parse('$baseUrl/objects'));
+  if (res.statusCode != 200) throw Exception('Failed to load objects');
+  return jsonDecode(res.body) as List<dynamic>;
+}
+
+Future<Map<String, dynamic>> createObject(Map<String, dynamic> data) async {
+  final res = await http.post(
+    Uri.parse('$baseUrl/objects'),
+    headers: {'Content-Type': 'application/json'},
+    body: jsonEncode(data),
+  );
+  if (res.statusCode != 201) throw Exception('Failed to create object');
+  return jsonDecode(res.body) as Map<String, dynamic>;
+}
+
+Future<List<dynamic>> fetchWorkLogs() async {
+  final res = await http.get(Uri.parse('$baseUrl/worklogs'));
+  if (res.statusCode != 200) throw Exception('Failed to load worklogs');
+  return jsonDecode(res.body) as List<dynamic>;
+}
+
+Future<Map<String, dynamic>> createWorkLog(Map<String, dynamic> data) async {
+  final res = await http.post(
+    Uri.parse('$baseUrl/worklogs'),
+    headers: {'Content-Type': 'application/json'},
+    body: jsonEncode(data),
+  );
+  if (res.statusCode != 201) throw Exception('Failed to create worklog');
+  return jsonDecode(res.body) as Map<String, dynamic>;
+}

--- a/frontend_flutter/pubspec.yaml
+++ b/frontend_flutter/pubspec.yaml
@@ -1,0 +1,19 @@
+name: frontend_flutter
+description: Flutter web app for Eventoria
+publish_to: "none"
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.5
+  provider: ^6.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- document the project layout
- add Go backend skeleton using Gin
- add Flutter web placeholder
- extend docker-compose with Go and Flutter services
- expand Go API with persistent models using GORM
- add simple Flutter web UI for objects and worklogs

## Testing
- `pip install -r requirements.txt`
- `pip install aiosqlite`
- `pytest -q`
- `go mod tidy` *(failed: Forbidden while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849173f88bc832282146cd7ed166d92